### PR TITLE
WIP: Rewrite closures into mutable objects

### DIFF
--- a/lib/revaluate.js
+++ b/lib/revaluate.js
@@ -80,7 +80,7 @@ module.exports = function revaluate(content, name, evaluate) {
           __closure[entry.index] = {};
         }
 
-        entry.node = closure
+        entry.node = closure;
 
         var name = node.name;
         var index = entry.index;

--- a/lib/revaluate.js
+++ b/lib/revaluate.js
@@ -90,6 +90,68 @@ module.exports = function revaluate(content, name, evaluate) {
     }
 
     if (node.type == 'VariableDeclaration') {
+      var closure = (function walk(node, declaration) {
+        if (node.type != 'BlockStatement' &&
+            node.type != 'Program') {
+          return walk(node.parent, name);
+        }
+
+        var body = node.body;
+        for (var i = 0; i < body.length; i++) {
+          var child = body[i];
+
+          if (child == declaration) {
+            if (child.kind != 'var') {
+              return node;
+            }
+
+            return (function walk(node) {
+              if (node.parent == null) {
+                return node;
+              }
+
+              if (node.type == 'FunctionDeclaration' ||
+                  node.type == 'FunctionExpression') {
+                return node.body;
+              }
+
+              if (node.parent) {
+                return walk(node.parent, name);
+              }
+
+              return node;
+            }(node));
+          }
+        }
+
+        if (node.parent) {
+          return walk(node.parent, name);
+        }
+      }(node.parent, node));
+
+      var entry = entries[range(closure)];
+      var index = entry.index;
+
+      var declarations = node.declarations;
+      for (var i = 0; i < declarations.length; i++) {
+        var declaration = declarations[i];
+
+        var name = declaration.id.name;
+        var code = declaration.toString();
+
+        __closure[index].__defineGetter__(name, function() {
+          delete __closure[index][name];
+          eval(code);
+
+          return __closure[index][name];
+        });
+
+        __closure[index].__defineSetter__(name, function(value) {
+          delete __closure[index][name];
+          __closure[index][name] = value;
+        });
+      }
+
       return node.toString()
         .replace(/var/, '');
     }

--- a/lib/revaluate.js
+++ b/lib/revaluate.js
@@ -2,6 +2,7 @@ var diff = require('fast-diff');
 var reshift = require('reshift');
 
 __cache = [];
+__closure = [];
 __function = [];
 
 module.exports = function revaluate(content, name, evaluate) {
@@ -43,6 +44,56 @@ module.exports = function revaluate(content, name, evaluate) {
 
   var entries = {};
   var output = reshift(content, function(node) {
+    if (node.type == 'Identifier') {
+      var closure = (function next(node, name) {
+        if (node.body) {
+          var body = node.body;
+          for (var i = 0; i < body.length; i++) {
+            var child = body[i];
+
+            if (child.type == 'VariableDeclaration') {
+              var declarations = child.declarations;
+              for (var j = 0; j < declarations.length; j++) {
+                var declaration = declarations[j];
+
+                var id = declaration.id;
+                if (id.name == name) {
+                  return node;
+                }
+              }
+            }
+          }
+        }
+
+        if (node.parent) {
+          return next(node.parent, name);
+        }
+      }(node, node.name));
+
+      if (closure) {
+        var entry = entries[range(closure)] = (
+          context.entries[key(closure)] || entries[range(closure)] || {}
+        );
+
+        if (entry.index == undefined) {
+          entry.index = __closure.length++;
+          __closure[entry.index] = {};
+        }
+
+        entry.node = closure
+
+        var name = node.name;
+        var index = entry.index;
+
+        return '__closure[' + index + '].' + name;
+      }
+    }
+
+    if (node.type == 'VariableDeclaration') {
+      return node.toString()
+        .replace(/var/, '');
+    }
+
     if (node.type == 'FunctionExpression' || node.type == 'FunctionDeclaration') {
       var entry = entries[range(node)] = (
         context.entries[key(node)] || entries[range(node)] || {}

--- a/lib/revaluate.js
+++ b/lib/revaluate.js
@@ -45,6 +45,10 @@ module.exports = function revaluate(content, name, evaluate) {
   var entries = {};
   var output = reshift(content, function(node) {
     if (node.type == 'Identifier') {
+      if (node.parent.type == 'MemberExpression' && node.parent.object != node) {
+        return node.toString();
+      }
+
       var closure = (function next(node, name) {
         if (node.body) {
           var body = node.body;

--- a/test/eval_closure.js
+++ b/test/eval_closure.js
@@ -44,3 +44,30 @@ for (var i = 0; i < 10; i++) {
 
   assert.equal(fn()(), 0);
 }
+
+var result = [];
+for (var i = 0; i < 10; i++) {
+  var fn = revaluate([
+    '(function() {',
+    '  return value;',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  result.push(fn);
+}
+
+revaluate([
+  'var value = 0;',
+  '(function() {',
+  '  return value;',
+   '})',
+].join('\n'), name, function(output) {
+  return eval(output.toString());
+});
+
+for (var i = 0; i < result.length; i++) {
+  var fn = result[i];
+  assert.equal(fn(), 0);
+}

--- a/test/eval_closure.js
+++ b/test/eval_closure.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+
+for (var i = 0; i < 10; i++) {
+  var fn = revaluate([
+    'var value = ' + i + ';',
+    '(function() {',
+    '  return value;',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  assert.equal(fn(), i);
+}
+
+for (var i = 0; i < 10; i++) {
+  var fn = revaluate([
+    'var value' + i + ' = 0;',
+    '(function() {',
+    '  return value' + i + ';',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  assert.equal(fn(), 0);
+}
+
+for (var i = 0; i < 10; i++) {
+  var fn = revaluate([
+    'var value' + i + ' = -1;',
+    '(function() {',
+    '  var value' + i + ' = 0;',
+    '  return function() {',
+    '    return value' + i + ';',
+    '  }',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  assert.equal(fn()(), 0);
+}

--- a/test/eval_member.js
+++ b/test/eval_member.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+
+for (var i = 0; i < 10; i++) {
+  var value = revaluate([
+    'var now = Date.now();',
+    'now',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  assert.ok(value);
+}

--- a/test/eval_variable.js
+++ b/test/eval_variable.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+
+for (var i = 0; i < 10; i++) {
+  var value = revaluate([
+    'var value = ' + i + ';',
+    'value',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  assert.equal(value, i);
+}

--- a/test/replace_closure.js
+++ b/test/replace_closure.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+
+var result = [];
+for (var i = 0; i < 10; i++) {
+  var fn = revaluate([
+    '(function() {',
+    '  return function() {',
+    '    return value;',
+    '  }',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  result.push(fn);
+}
+
+for (var i = 0; i < result.length; i++) {
+  var fn = result[i];
+  result[i] = fn();
+}
+
+for (var i = 0; i < 10; i++) {
+  var value = Math.random();
+  revaluate([
+    '(function() {',
+    '  var value = ' + value +';',
+    '  return function() {',
+    '    return value;',
+    '  }',
+    '})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  for (var i = 0; i < result.length; i++) {
+    var fn = result[i];
+    assert.equal(fn(), value);
+  }
+}


### PR DESCRIPTION
This rewrites identifiers in such a way that closures become tangible objects with late-lazy initialisation.

For example, take the following potential closures

```js
setTimeout(function beep() {
  setTimeout(function boop() {
    console.log(typeof value);
    setTimeout(beep);
  }, 1000);
}, 1000);
```

Change that into the following

```js
setTimeout(function beep() {
  var value = 0;
  setTimeout(function boop() {
    console.log(typeof value);
    setTimeout(beep);
  }, 1000);
}, 1000);
```

Previously, this would continue to output undefined but with this it will reflect the intended change and output `number`.

This can also unblock #9, since closures are mutable and accessible there is no need to evaluate in-place.