### PR TITLE
WIP: Cache classes

### DIFF
--- a/lib/revaluate.js
+++ b/lib/revaluate.js
@@ -43,6 +43,30 @@ module.exports = function revaluate(content, name, evaluate) {
 
   var entries = {};
   var output = reshift(content, function(node) {
+    if (node.type == 'ClassDeclaration' || node.type == 'ClassExpression') {
+      var entry = entries[range(node)] = (
+        context.entries[key(node)] || entries[range(node)] || {}
+      );
+
+      entry.node = node;
+
+      if (entry.index == undefined) {
+        entry.index = __cache.length++;
+      }
+
+      var index = entry.index;
+      var name = node.id ? node.id.name : '';
+      var code = node.toString();
+
+      return [
+        '($index in __cache ? __cache[$index] : __cache[$index] = $code)',
+      ].join('\n')
+        .replace(/^/, node.type == 'ClassDeclaration' ? 'var $name = ' : '')
+        .replace(/\$name/g, name)
+        .replace(/\$index/g, index)
+        .replace(/\$code/g, code);
+    }
+
     if (node.type == 'MethodDefinition') {
       var entry = entries[range(node)] = (
         context.entries[key(node)] || entries[range(node)] || {}

--- a/test/cache_class_declaration.js
+++ b/test/cache_class_declaration.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+var result = [];
+
+for (var i = 0; i < 10; i++) {
+  var value = i;
+
+  var cls = revaluate([
+    'class Class {}',
+    'Class',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  result.push(cls);
+}
+
+for (var i = 0; i < result.length; i++) {
+  for (var j = 0; j < result.length; j++) {
+    assert.equal(result[i], result[j]);
+  }
+}

--- a/test/cache_class_expression.js
+++ b/test/cache_class_expression.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var revaluate = require('..');
+
+var name = Date.now().toString(36) + '.js';
+var result = [];
+
+for (var i = 0; i < 10; i++) {
+  var value = i;
+
+  var cls = revaluate([
+    '(class Class {})',
+  ].join('\n'), name, function(output) {
+    return eval(output.toString());
+  });
+
+  result.push(cls);
+}
+
+for (var i = 0; i < result.length; i++) {
+  for (var j = 0; j < result.length; j++) {
+    assert.equal(result[i], result[j]);
+  }
+}


### PR DESCRIPTION
Each revaluation currently yields a new set of classes, since classes are stateless this kind-of looks okay but it means the connection between instances and classes are not there.

Since these classes share the same proxy functions, it looks like they are being updated but an `instance` of `Robot` created in a previous revaluation will not be an `instanceof` a later revaluated `Robot` class, which is just wrong behaviour since this means you cannot add or remove properties to instances.